### PR TITLE
Patch 2. Encode solution on client

### DIFF
--- a/main.js
+++ b/main.js
@@ -1742,7 +1742,7 @@ this.wordle = this.wordle || {}, this.wordle.bundle = function(exports) {
         rowIndex : self.rowIndex,
         boardState : self.boardState,
         evaluations : self.evaluations,
-        solution : self.solution,
+        solution : encodeURI(self.solution),
         gameStatus : self.gameStatus
       }), check("event", "level_start", {
         level_name : combine(self.solution)
@@ -1868,7 +1868,7 @@ this.wordle = this.wordle || {}, this.wordle.bundle = function(exports) {
             rowIndex : this.rowIndex,
             boardState : this.boardState,
             evaluations : this.evaluations,
-            solution : this.solution,
+            solution : encodeURI(this.solution),
             gameStatus : this.gameStatus,
             lastPlayedTs : Date.now()
           });


### PR DESCRIPTION
1. I have seen that the `solution` can be found **in** the `LocalStorage` on the client

    ![Здымак экрана ад 2023-05-26 19-30-22](https://github.com/OloloPhilolo/wordle-by/assets/39376451/f22dbb4d-d6e3-469a-951c-296457880368)

2. The `btoa()` is deprecated, that's why I used `encodeURI()`
This is how the `solution` key looks with the change.
It can still be decoded with `decodeURI()` if needed.

    ![Здымак экрана ад 2023-05-26 19-37-23](https://github.com/OloloPhilolo/wordle-by/assets/39376451/220ce466-05ce-452c-9656-d866a4ced804)

3. I have tested it. And the solution is not used on the client at all.
